### PR TITLE
Remove Xbox Packages Without Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ __Alternatives__: [MPC-HC](https://mpc-hc.org/), [VLC](https://www.videolan.org/
 ### Xbox and Game DVR
 In the PowerShell, type:
 ```
-Get-AppxPackage -AllUsers *xbox* | Remove-AppxPackage
+Get-AppxPackage *xbox* -AllUsers | Where-Object {$_.name -notlike "*xboxgamecallable*" } | Remove-AppxPackage
 ```
-You can ignore any error that pops up.  
 In the command prompt, type:
 ```
 sc delete XblAuthManager


### PR DESCRIPTION
For some reason `Microsoft.XboxGameCallableUI` will break Windows if uninstalled. The new command will skip attempting to remove this package so that there is no error when removing Xbox.

```powershell
PS C:\Windows\system32>Get-AppxPackage *xbox* -AllUsers | Where-Object {$_.name -notlike "*xboxgamecallable*" } | Remove-AppxPackage
PS C:\Windows\system32>
```

Previously the command would halt when attempting to remove `XboxGameCallableUI` and wouldn't uninstall the other Xbox apps (`Microsoft.Xbox.TCUI`, `Microsoft.XboxApp`, etc.) 

```powershell
PS C:\Windows\system32> Get-AppxPackage *xbox* -AllUsers | Remove-AppxPackage
Remove-AppxPackage : Deployment failed with HRESULT: 0x80073CFA, Removal failed. Please contact your software vendor. (Exception from HRESULT: 0x80073CFA)
error 0x80070032: AppX Deployment Remove operation on package Microsoft.XboxGameCallableUI_1000.17134.1.0_neutral_neutral_cw5n1h2txyewy from: C:\Windows\SystemApps\Microsoft.XboxGameCallableUI_cw5n1h2txyewy failed. This app is part of
Windows and cannot be uninstalled on a per-user basis. An administrator can attempt to remove the app from the computer using Turn Windows Features on or off. However, it may not be possible to uninstall the app.
NOTE: For additional information, look for [ActivityId] 8b43b884-0755-0002-d5f6-438b5507d501 in the Event Log or use the command line Get-AppxLog -ActivityID 8b43b884-0755-0002-d5f6-438b5507d501
At line:1 char:36
+ Get-AppxPackage *xbox* -AllUsers | Remove-AppxPackage
+                                    ~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : WriteError: (Microsoft.XboxG...l_cw5n1h2txyewy:String) [Remove-AppxPackage], IOException
    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.RemoveAppxPackageCommand

PS C:\Windows\system32>
```